### PR TITLE
Update toolctl

### DIFF
--- a/v0/toolctl/darwin-amd64/0.1.0.yaml
+++ b/v0/toolctl/darwin-amd64/0.1.0.yaml
@@ -1,0 +1,2 @@
+url: https://github.com/toolctl/toolctl/releases/download/v0.1.0/toolctl_0.1.0_darwin_amd64.tar.gz
+sha256: 3432dcf62c799dc2f5253245cc44f9aa58155370cff752aeb352d1e01af8eacf

--- a/v0/toolctl/linux-amd64/0.1.0.yaml
+++ b/v0/toolctl/linux-amd64/0.1.0.yaml
@@ -1,0 +1,2 @@
+url: https://github.com/toolctl/toolctl/releases/download/v0.1.0/toolctl_0.1.0_linux_amd64.tar.gz
+sha256: 7e18bd45fcddd1b5887bf50832baeabe3b08c99be541fd794e065f5d3b4537ac

--- a/v0/toolctl/linux-amd64/meta.yaml
+++ b/v0/toolctl/linux-amd64/meta.yaml
@@ -1,0 +1,3 @@
+version:
+  earliest: 0.1.0
+  latest: 0.1.0

--- a/v0/toolctl/meta.yaml
+++ b/v0/toolctl/meta.yaml
@@ -1,4 +1,4 @@
 description: Control your tools
-downloadURLTemplate: https://github.com/{{.Name}}/{{.Name}}/releases/download/v{{.Version}}/{{.Name}}-{{.OS}}-{{.Arch}}.tar.gz
+downloadURLTemplate: https://github.com/{{.Name}}/{{.Name}}/releases/download/v{{.Version}}/{{.Name}}_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz
 homepage: https://github.com/toolctl/toolctl
 versionArgs: [version, --short]


### PR DESCRIPTION
This PR adds toolctl 0.1.0 for darwin_amd64 and linux_amd64.